### PR TITLE
List button fix

### DIFF
--- a/src/molecules/List/Item/Item.jsx
+++ b/src/molecules/List/Item/Item.jsx
@@ -19,7 +19,7 @@ const ListItem = ({
 }) => (
   <BaseElement hard css={css} element={element} role={role} {...props}>
     {Children.count(children) === 1 ? (
-      <Body center={center} reverse={reverse} small={small} {...props}>
+      <Body center={center} reverse={reverse} small={small}>
         {children}
       </Body>
     ) : (


### PR DESCRIPTION
Убрал лишнюю передачу свойств. Любое из возможных свойств передать не получится, потому что они либо перехватываются уровнем выше либо не используются на уровне ниже. Едиственное что получается передать это "atomRef", но тогда возникают ошибки.

Removed extra transfer properties. Any of the possible properties cannot be transferred because they are either intercepted at a higher level or not used at a lower level. The only thing that turns out to be to pass on is the "atomRef", but then errors occur.